### PR TITLE
BaSP-MR-27: test activities get and post

### DIFF
--- a/src/controllers/activity.js
+++ b/src/controllers/activity.js
@@ -46,9 +46,9 @@ const getActivitiesById = (req, res) => {
 };
 
 const createActivities = async (req, res) => {
+  const { name, description, isActive } = req.body;
   const existingActivity = await Activity.findOne({ name: req.body.name });
   if (!existingActivity) {
-    const { name, description, isActive } = req.body;
     return Activity.create({
       name,
       description,

--- a/src/controllers/activity.js
+++ b/src/controllers/activity.js
@@ -7,7 +7,7 @@ const getAllActivities = (req, res) => {
       if (activities.length === 0) {
         return res.status(404).json({
           message: 'There are no activities',
-          error: false,
+          error: true,
         });
       }
       return res.status(200).json({
@@ -33,7 +33,7 @@ const getActivitiesById = (req, res) => {
         return res.status(404).json({
           message: `There is no activity with id: ${id}`,
           data: activity,
-          error: false,
+          error: true,
         });
       }
       return res.status(200).json({
@@ -84,7 +84,7 @@ const updateActivities = (req, res) => {
         res.status(404).json({
           message: `There is no activity with id:${id}`,
           data: undefined,
-          error: false,
+          error: true,
 
         });
       } else {
@@ -114,7 +114,7 @@ const deleteActivities = (req, res) => {
         res.status(404).json({
           message: `There is no activity with id:${id}`,
           data: undefined,
-          error: false,
+          error: true,
         });
       } else {
         res.status(200).json({

--- a/src/seeds/activity.js
+++ b/src/seeds/activity.js
@@ -1,0 +1,34 @@
+import mongoose from 'mongoose';
+
+export default [
+  {
+    _id:new mongoose.Types.objectId('64677fdefc13ae39f1753b24'),
+    name:'Artemus',
+    desciption:'vestibulum aliquet ultrices erat tortor sollicitudin mi sit amet lobortis sapien sapien non mi integer ac neque duis',
+    isActive: false
+  },
+  {
+    _id: new mongoose.Types.objectId('64677fdefc13ae39f1753b25'),
+    name: 'Nisse',
+    desciption: 'interdum mauris non ligula pellentesque ultrices phasellus id sapien in sapien iaculis congue vivamus metus arcu adipiscing molestie hendrerit at vulputate vitae',
+    isActive: true
+  },
+  {
+    _id: new mongoose.Types.objectId('64677fdefc13ae39f1753b26'),
+    name: 'Chandal',
+    desciption: 'quam pede lobortis ligula sit amet eleifend pede libero quis orci nullam molestie nibh in',
+    isActive: false
+  },
+  {
+    _id: new mongoose.Types.objectId('64677fdefc13ae39f1753b27'),
+    name: 'Nerita',
+    desciption: 'odio justo sollicitudin ut suscipit a feugiat et eros vestibulum ac est',
+    isActive: true
+  },
+  {
+    _id: new mongoose.Types.objectId('64677fdefc13ae39f1753b28'),
+    name: 'Tracee',
+    desciption: 'potenti in eleifend quam a odio',
+    isActive: true
+  }
+];

--- a/src/seeds/activity.js
+++ b/src/seeds/activity.js
@@ -2,33 +2,33 @@ import mongoose from 'mongoose';
 
 export default [
   {
-    _id:new mongoose.Types.objectId('64677fdefc13ae39f1753b24'),
-    name:'Artemus',
-    desciption:'vestibulum aliquet ultrices erat tortor sollicitudin mi sit amet lobortis sapien sapien non mi integer ac neque duis',
-    isActive: false
+    _id: new mongoose.Types.ObjectId('64677fdefc13ae39f1753b24'),
+    name: 'Artemus',
+    description: 'vestibulum aliquet ultrices erat tortor sollicitudin mi sit amet lobortis sapien sapien non mi integer ac neque duis',
+    isActive: false,
   },
   {
-    _id: new mongoose.Types.objectId('64677fdefc13ae39f1753b25'),
+    _id: new mongoose.Types.ObjectId('64677fdefc13ae39f1753b25'),
     name: 'Nisse',
-    desciption: 'interdum mauris non ligula pellentesque ultrices phasellus id sapien in sapien iaculis congue vivamus metus arcu adipiscing molestie hendrerit at vulputate vitae',
-    isActive: true
+    description: 'interdum mauris non ligula pellentesque ultrices phasellus id sapien in sapien iaculis congue vivamus metus arcu adipiscing molestie hendrerit at vulputate vitae',
+    isActive: true,
   },
   {
-    _id: new mongoose.Types.objectId('64677fdefc13ae39f1753b26'),
+    _id: new mongoose.Types.ObjectId('64677fdefc13ae39f1753b26'),
     name: 'Chandal',
-    desciption: 'quam pede lobortis ligula sit amet eleifend pede libero quis orci nullam molestie nibh in',
-    isActive: false
+    description: 'quam pede lobortis ligula sit amet eleifend pede libero quis orci nullam molestie nibh in',
+    isActive: false,
   },
   {
-    _id: new mongoose.Types.objectId('64677fdefc13ae39f1753b27'),
+    _id: new mongoose.Types.ObjectId('64677fdefc13ae39f1753b27'),
     name: 'Nerita',
-    desciption: 'odio justo sollicitudin ut suscipit a feugiat et eros vestibulum ac est',
-    isActive: true
+    description: 'odio justo sollicitudin ut suscipit a feugiat et eros vestibulum ac est',
+    isActive: true,
   },
   {
-    _id: new mongoose.Types.objectId('64677fdefc13ae39f1753b28'),
+    _id: new mongoose.Types.ObjectId('64677fdefc13ae39f1753b28'),
     name: 'Tracee',
-    desciption: 'potenti in eleifend quam a odio',
-    isActive: true
-  }
+    description: 'potenti in eleifend quam a odio',
+    isActive: true,
+  },
 ];

--- a/src/tests/activity.test.js
+++ b/src/tests/activity.test.js
@@ -60,7 +60,7 @@ describe('GET /api/activities', () => {
   test('The status must be 404, if the url is wrong', async () => {
     const response = await request(app).get('/activities').send();
     expect(response.status).toBe(404);
-    expect(response.error).toBeTruthy();
+    expect(response.body.error).toBeUndefined();
   });
   describe('GET /api/activities', () => {
     test('The database must return 404 if it\'s empty of activities. An said There are no activities', async () => {
@@ -102,7 +102,7 @@ describe('GET BY ID /api/activities/:id', () => {
   test('The status must be 404, if the url is wrong', async () => {
     const response = await request(app).get('/activities/:id').send();
     expect(response.status).toBe(404);
-    expect(response.error).toBeTruthy();
+    expect(response.body.error).toBeUndefined();
   });
 });
 
@@ -110,7 +110,7 @@ describe('POST /api/activities', () => {
   test('The status must be 404, if the url is wrong', async () => {
     const response = await request(app).post('/activities').send();
     expect(response.status).toBe(404);
-    expect(response.error).toBeTruthy();
+    expect(response.body.error).toBeUndefined();
   });
   test('When create an activities status must be 201, and must have name, description and isActive defined', async () => {
     const response = await request(app).post('/api/activities').send(mockActivity);

--- a/src/tests/activity.test.js
+++ b/src/tests/activity.test.js
@@ -1,1 +1,141 @@
-test.skip('skip', () => {});
+import request from 'supertest';
+import app from '../app';
+import activity from '../models/activity';
+import activitySeed from '../seeds/activity';
+
+const mockActivity = {
+  name: 'Boxing',
+  description: 'vestibulum aliquet ultrices erat tortor sollicitudin mi non mi integer ac neque duis',
+  isActive: false,
+};
+
+const mockActivityExistingName = {
+  name: 'Chandal',
+  description: 'Any description',
+  isActive: false,
+};
+
+const mockLessName = {
+  name: '',
+  description: 'Some text',
+  isActive: true,
+};
+
+const mockLessDescription = {
+  name: 'Name',
+  description: '',
+  isActive: true,
+};
+
+const mockLessIsActive = {
+  name: 'Names',
+  description: 'some description',
+  isActive: '',
+};
+
+beforeAll(async () => {
+  await activity.collection.insertMany(activitySeed);
+});
+
+describe('GET /api/activities', () => {
+  test('The database must return 200 if is not empty of activities', async () => {
+    const response = await request(app).get('/api/activities').send();
+    expect(response.body.data.length).toBeGreaterThan(0);
+    expect(response.status).toBe(200);
+    expect(response.error).toBeFalsy();
+  });
+  test('The status must be 404, if the url is wrong', async () => {
+    const response = await request(app).get('/activities').send();
+    expect(response.status).toBe(404);
+    expect(response.error).toBeTruthy();
+  });
+  test('If are activities, data must said "Complete activities list" ', async () => {
+    const response = await request(app).get('/api/activities').send();
+    expect(response.body.message).toMatch(/Complete activities list/);
+    expect(response.error).toBeFalsy();
+  });
+});
+
+describe('GET BY ID /api/activities/:id', () => {
+  test('The database must return 200 if the id exist', async () => {
+    const response = await request(app).get('/api/activities/64677fdefc13ae39f1753b24').send();
+    expect(response.status).toBe(200);
+    expect(response.body).toBeDefined();
+    expect(response.body.data).toHaveProperty('_id');
+    expect(response.body.data).toHaveProperty('name');
+    expect(response.body.data).toHaveProperty('description');
+    expect(response.body.data).toHaveProperty('isActive');
+    expect(response.error).toBeFalsy();
+  });
+  test('The database must return 404 if the id does not exist', async () => {
+    const nonExistentId = '64677fdefc13ae39f1753b99';
+    const response = await request(app).get(`/api/activities/${nonExistentId}`).send();
+    expect(response.status).toBe(404);
+    expect(response.body.message).toMatch(/There is no activity with id/);
+    expect(response.error).toBeTruthy();
+  });
+  test('The database must return 400 if the id is wrong, and said Invalid activity id', async () => {
+    const idNotValid = '12345';
+    const response = await request(app).get(`/api/activities/${idNotValid}`).send();
+    expect(response.status).toBe(400);
+    expect(response.body.message).toMatch(/Invalid activity id/);
+    expect(response.error).toBeTruthy();
+  });
+  test('The status must be 404, if the url is wrong', async () => {
+    const response = await request(app).get('/activities/:id').send();
+    expect(response.status).toBe(404);
+    expect(response.error).toBeTruthy();
+  });
+});
+
+describe('POST /api/activities', () => {
+  test('The status must be 404, if the url is wrong', async () => {
+    const response = await request(app).post('/activities').send();
+    expect(response.status).toBe(404);
+    expect(response.error).toBeTruthy();
+  });
+  test('When create an activities status must be 201, and must have name, description and isActive defined', async () => {
+    const response = await request(app).post('/api/activities').send(mockActivity);
+    expect(response.status).toBe(201);
+    expect(response.body).toBeDefined();
+    expect(response.body.data).toHaveProperty('name');
+    expect(response.body.data).toHaveProperty('description');
+    expect(response.body.data).toHaveProperty('isActive');
+    expect(response.error).toBeFalsy();
+  });
+  test('If name is already existing, status must be 409', async () => {
+    const response = await request(app).post('/api/activities').send(mockActivityExistingName);
+    expect(response.status).toBe(409);
+    expect(response.body.message).toMatch('Activity with that name already exists');
+    expect(response.error).toBeTruthy();
+  });
+  test('If name is not defined, status must be 400, name is required', async () => {
+    const response = await request(app).post('/api/activities').send(mockLessName);
+    expect(response.status).toBe(400);
+    expect(response.body.message).toMatch('There was an error: \"name\" is not allowed to be empty');
+    expect(response.error).toBeTruthy();
+  });
+  test('If description is not defined, status must be 400, description is required', async () => {
+    const response = await request(app).post('/api/activities').send(mockLessDescription);
+    expect(response.status).toBe(400);
+    expect(response.body.message).toMatch('There was an error: \"description\" is not allowed to be empty');
+    expect(response.error).toBeTruthy();
+  });
+  test('If isActive is not defined, status must be 400, isActive is required', async () => {
+    const response = await request(app).post('/api/activities').send(mockLessIsActive);
+    expect(response.status).toBe(400);
+    expect(response.body.message).toMatch('There was an error: \"isActive\" must be a boolean');
+    expect(response.error).toBeTruthy();
+  });
+});
+
+// It's after the others tests, because delete all data for correc test. It has to be the last.
+describe('GET /api/activities', () => {
+  test('The database must return 404 if it\'s empty of activities. An said There are no activities', async () => {
+    await activity.collection.deleteMany({});
+    const response = await request(app).get('/api/activities').send();
+    expect(response.body.data).toBe(undefined);
+    expect(response.status).toBe(404);
+    expect(response.body.message).toMatch(/There are no activities/);
+  });
+});


### PR DESCRIPTION
Added test for get, get by id and post.
One test for GET it's at the end of the file because to test it, had to clean the seed, and if you let the test up, the other test fail, because are no data in the seed.