### PR TITLE
BaSP-MR-154: Fixed activity edit bug

### DIFF
--- a/src/controllers/activity.js
+++ b/src/controllers/activity.js
@@ -104,7 +104,7 @@ const updateActivities = async (req, res) => {
   const { name, description, isActive } = req.body;
 
   try {
-    const existingActivity = await Activity.findOne({ name: req.body.name });
+    const existingActivity = await Activity.findOne({ name, description });
 
     if (existingActivity) {
       return res.status(400).json({


### PR DESCRIPTION
In this PR, a bug preventing the editing of an Activity has been fixed. The bug was caused by a condition that only checked if the name of the Activity in the request body was equal to the existing name while ignoring the description. This condition caused the editing process to fail