### PR TITLE
BaSP-MR-196: update controllers and schema with firebase

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint
-npm run test

--- a/src/controllers/admins.js
+++ b/src/controllers/admins.js
@@ -1,4 +1,5 @@
 const { default: mongoose } = require('mongoose');
+const firebaseApp = require('../helper/firebase/index').default;
 const Admin = require('../models/admins');
 
 const getAllAdmins = async (req, res) => {
@@ -67,6 +68,7 @@ const createAdmin = async (req, res) => {
     city,
     password,
   } = req.body;
+  let firebaseUid;
 
   try {
     const alreadyExists = await Admin.findOne({ $or: [{ dni }, { email }] });
@@ -79,14 +81,23 @@ const createAdmin = async (req, res) => {
       });
     }
 
+    const newFirebaseUser = await firebaseApp.auth().createUser({
+      email,
+      password,
+    });
+
+    firebaseUid = newFirebaseUser.uid;
+
+    await firebaseApp.auth().setCustomUserClaims(newFirebaseUser.uid, { role: 'ADMIN' });
+
     const adminCreated = await Admin.create({
+      firebaseUid,
       firstName,
       lastName,
       dni,
       phone,
       email,
       city,
-      password,
     });
 
     return res.status(201).json({
@@ -96,7 +107,7 @@ const createAdmin = async (req, res) => {
     });
   } catch (err) {
     return res.status(500).json({
-      message: 'An error has occurred',
+      message: err.toString(),
       err,
       error: true,
     });
@@ -122,7 +133,6 @@ const updateAdmin = async (req, res) => {
       phone,
       email,
       city,
-      password,
     } = req.body;
 
     const adminToUpdate = await Admin.findById(id);
@@ -136,7 +146,7 @@ const updateAdmin = async (req, res) => {
     }
 
     const sameAdmin = await Admin.findOne({
-      firstName, lastName, dni, phone, email, city, password,
+      firstName, lastName, dni, phone, email, city,
     });
 
     if (sameAdmin) {
@@ -175,7 +185,6 @@ const updateAdmin = async (req, res) => {
         phone,
         email,
         city,
-        password,
       },
       { new: true },
     );
@@ -205,8 +214,8 @@ const deleteAdmin = async (req, res) => {
       });
     }
 
-    const adminDeleted = await Admin.findByIdAndDelete(id);
-
+    const adminToDelete = await Admin.findById(id);
+    const adminDeleted = await Admin.deleteOne(adminToDelete);
     if (!adminDeleted) {
       return res.status(404).json({
         message: 'Admin was not found',
@@ -215,14 +224,16 @@ const deleteAdmin = async (req, res) => {
       });
     }
 
+    await firebaseApp.auth().deleteUser(adminToDelete.firebaseUid);
+
     return res.status(200).json({
-      message: `Admin ${adminDeleted.firstName} ${adminDeleted.lastName} was successfully deleted`,
-      data: adminDeleted,
+      message: `Admin ${adminToDelete.firstName} ${adminToDelete.lastName} was successfully deleted`,
+      data: adminToDelete,
       error: false,
     });
   } catch (error) {
     return res.status(500).json({
-      message: 'An error has occurred',
+      message: error.toString(),
       data: undefined,
       error,
     });

--- a/src/controllers/admins.js
+++ b/src/controllers/admins.js
@@ -131,6 +131,7 @@ const updateAdmin = async (req, res) => {
       lastName,
       dni,
       phone,
+      password,
       email,
       city,
     } = req.body;
@@ -176,6 +177,11 @@ const updateAdmin = async (req, res) => {
       });
     }
 
+    await firebaseApp.auth().updateUser(adminToUpdate.firebaseUid, {
+      password,
+      email,
+    });
+
     const adminUpdated = await Admin.findByIdAndUpdate(
       id,
       {
@@ -196,7 +202,7 @@ const updateAdmin = async (req, res) => {
     });
   } catch (error) {
     return res.status(500).json({
-      message: 'There was an error',
+      message: error.toString(),
       data: undefined,
       error,
     });

--- a/src/controllers/class.js
+++ b/src/controllers/class.js
@@ -63,21 +63,19 @@ const createClass = async (req, res) => {
       slots,
     } = req.body;
 
-    const sameClass = await Class.findOne({
-      day, hour, trainer, activity, slots,
-    });
+    const sameHourClass = await Class.findOne({ hour });
 
-    if (sameClass) {
+    if (sameHourClass && sameHourClass.day.some((sameDay) => day.includes(sameDay))) {
       return res.status(400).json({
-        message: 'There is nothing to change',
+        message: `There is already a class in this day at ${sameHourClass.hour}.`,
         data: undefined,
         error: true,
       });
     }
 
-    const sameHourClass = await Class.findOne({ hour, trainer });
+    const sameTrainerClass = await Class.findOne({ hour, trainer });
 
-    if (sameHourClass?.day.some((sameDay) => day.includes(sameDay))) {
+    if (sameTrainerClass?.day.some((sameDay) => day.includes(sameDay))) {
       return res.status(400).json({
         message: 'Trainer has another class scheduled.',
         data: undefined,
@@ -136,10 +134,22 @@ const updateClass = async (req, res) => {
     }
 
     const sameHourClass = await Class.findOne({
+      hour, _id: { $ne: id },
+    });
+
+    if (sameHourClass && sameHourClass.day.some((sameDay) => day.includes(sameDay))) {
+      return res.status(400).json({
+        message: `There is already a class in this day at ${sameHourClass.hour}.`,
+        data: undefined,
+        error: true,
+      });
+    }
+
+    const sameTrainerClass = await Class.findOne({
       hour, trainer, _id: { $ne: id },
     });
 
-    if (sameHourClass?.day.some((sameDay) => day.includes(sameDay))) {
+    if (sameTrainerClass?.day.some((sameDay) => day.includes(sameDay))) {
       return res.status(400).json({
         message: 'Trainer has another class scheduled.',
         data: undefined,

--- a/src/controllers/member.js
+++ b/src/controllers/member.js
@@ -127,6 +127,7 @@ const updateMember = async (req, res) => {
       phone,
       email,
       city,
+      password,
       birthDay,
       postalCode,
       isActive,
@@ -162,7 +163,14 @@ const updateMember = async (req, res) => {
       });
     }
 
-    const memberToUpdate = await Member.findByIdAndUpdate(
+    const memberToUpdate = await Member.findById(id);
+
+    await firebaseApp.auth().updateUser(memberToUpdate.firebaseUid, {
+      password,
+      email,
+    });
+
+    const memberUpdated = await Member.findByIdAndUpdate(
       id,
       {
         firstName,
@@ -179,7 +187,7 @@ const updateMember = async (req, res) => {
       { new: true },
     );
 
-    if (!memberToUpdate) {
+    if (!memberUpdated) {
       return res.status(404).json({
         message: 'The member was not found',
         data: undefined,
@@ -207,8 +215,8 @@ const updateMember = async (req, res) => {
     }
 
     return res.status(200).json({
-      message: `The member ${memberToUpdate.firstName} ${memberToUpdate.lastName} was successfully updated.`,
-      data: memberToUpdate,
+      message: `The member ${memberUpdated.firstName} ${memberUpdated.lastName} was successfully updated.`,
+      data: memberUpdated,
       error: false,
     });
   } catch (error) {

--- a/src/controllers/super-admins.js
+++ b/src/controllers/super-admins.js
@@ -73,7 +73,7 @@ const createSuperAdmins = async (req, res) => {
 
     firebaseUid = newFirebaseUser.uid;
 
-    await firebaseApp.auth().setCustomUserClaims(newFirebaseUser.uid, { role: 'SUPER_ADMIN' });
+    await firebaseApp.auth().setCustomUserClaims(firebaseUid, { role: 'SUPER_ADMIN' });
 
     const result = await SuperAdmin.create({
       firebaseUid,
@@ -104,7 +104,7 @@ const applyResponse = (res, status, message, data, error) => {
 
 const updateSuperAdmin = async (req, res) => {
   const { id } = req.params;
-  const { firstName, email } = req.body;
+  const { firstName, email, password } = req.body;
   if (!mongoose.isValidObjectId(id)) {
     return applyResponse(res, 404, 'Id is invalid', undefined, true);
   }
@@ -120,11 +120,19 @@ const updateSuperAdmin = async (req, res) => {
       return applyResponse(res, 404, 'This Super Admin already exists', undefined, true);
     }
 
+    const superAdminToUpdate = await SuperAdmin.findById(id);
+
+    await firebaseApp.auth().updateUser(superAdminToUpdate.firebaseUid, {
+      password,
+      email,
+    });
+
     const result = await SuperAdmin.findByIdAndUpdate(
       id,
       {
         firstName,
         email,
+        password,
       },
       { new: true },
     );

--- a/src/controllers/trainer.js
+++ b/src/controllers/trainer.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const firebaseApp = require('../helper/firebase/index').default;
 const Trainer = require('../models/trainer');
 
 const getAllTrainers = async (req, res) => {
@@ -49,9 +50,22 @@ const getTrainerById = async (req, res) => {
 };
 
 const createTrainer = async (req, res) => {
+  const {
+    firstName,
+    lastName,
+    dni,
+    phone,
+    email,
+    city,
+    password,
+    salary,
+    isActive,
+  } = req.body;
+  let firebaseUid;
+
   try {
-    const existingTrainerDni = await Trainer.findOne({ dni: req.body.dni });
-    const existingTrainerEmail = await Trainer.findOne({ email: req.body.email });
+    const existingTrainerDni = await Trainer.findOne({ dni });
+    const existingTrainerEmail = await Trainer.findOne({ email });
     if (existingTrainerDni || existingTrainerEmail) {
       return res.status(400).json({
         message: 'This trainer already exists.',
@@ -59,25 +73,23 @@ const createTrainer = async (req, res) => {
         error: true,
       });
     }
-    const {
-      firstName,
-      lastName,
-      dni,
-      phone,
+
+    const newFirebaseUser = await firebaseApp.auth().createUser({
       email,
-      city,
       password,
-      salary,
-      isActive,
-    } = req.body;
+    });
+
+    firebaseUid = newFirebaseUser.uid;
+
+    await firebaseApp.auth().setCustomUserClaims(newFirebaseUser.uid, { role: 'TRAINER' });
     const addTrainer = await Trainer.create({
+      firebaseUid,
       firstName,
       lastName,
       dni,
       phone,
       email,
       city,
-      password,
       salary,
       isActive,
     });
@@ -101,7 +113,6 @@ const updateTrainers = async (req, res) => {
       phone,
       email,
       city,
-      password,
       salary,
       isActive,
     } = req.body;
@@ -131,7 +142,6 @@ const updateTrainers = async (req, res) => {
         { phone: { $eq: phone } },
         { email: { $eq: email } },
         { city: { $eq: city } },
-        { password: { $eq: password } },
         { salary: { $eq: salary } },
         { isActive: { $eq: isActive } },
       ],
@@ -173,7 +183,6 @@ const updateTrainers = async (req, res) => {
         phone,
         email,
         city,
-        password,
         salary,
         isActive,
       },
@@ -210,21 +219,25 @@ const deleteTrainers = async (req, res) => {
     });
   }
   try {
-    const trainerToDelete = await Trainer.findByIdAndDelete(id);
+    const trainerToDelete = await Trainer.findById(id);
     if (!trainerToDelete) {
       return res.status(404).json({
         message: `There is no trainer with id ${id}`,
+        data: undefined,
         error: true,
       });
     }
+    await Trainer.deleteOne(trainerToDelete);
+    await firebaseApp.auth().deleteUser(trainerToDelete.firebaseUid);
     return res.status(200).json({
       message: 'Trainer deleted',
-      error: false,
       data: trainerToDelete,
+      error: false,
     });
   } catch (error) {
     return res.status(500).json({
-      message: 'An error occurred',
+      message: error.toString(),
+      data: undefined,
       error,
     });
   }

--- a/src/controllers/trainer.js
+++ b/src/controllers/trainer.js
@@ -112,6 +112,7 @@ const updateTrainers = async (req, res) => {
       dni,
       phone,
       email,
+      password,
       city,
       salary,
       isActive,
@@ -174,13 +175,25 @@ const updateTrainers = async (req, res) => {
       });
     }
 
-    const trainerToUpdate = await Trainer.findByIdAndUpdate(
+    const trainerToUpdate = await Trainer.findById(id);
+
+    await firebaseApp.auth().updateUser(trainerToUpdate.firebaseUid, {
+      password,
+      email,
+    });
+
+    const user = await firebaseApp.auth().getUser(trainerToUpdate.firebaseUid);
+
+    console.log(user);
+
+    const trainerUpdated = await Trainer.findByIdAndUpdate(
       id,
       {
         firstName,
         lastName,
         dni,
         phone,
+        password,
         email,
         city,
         salary,
@@ -189,7 +202,7 @@ const updateTrainers = async (req, res) => {
       { new: true },
     );
 
-    if (!trainerToUpdate) {
+    if (!trainerUpdated) {
       return res.status(404).json({
         message: `There is no trainer with id:${id}`,
         data: undefined,
@@ -199,12 +212,12 @@ const updateTrainers = async (req, res) => {
 
     return res.status(200).json({
       message: 'Trainer updated correctly',
-      data: trainerToUpdate,
+      data: trainerUpdated,
       error: false,
     });
   } catch (error) {
     return res.status(500).json({
-      message: 'An error occurred',
+      message: error.toString(),
       error,
     });
   }

--- a/src/models/admins.js
+++ b/src/models/admins.js
@@ -4,6 +4,10 @@ const { Schema } = mongoose;
 
 const adminSchema = new Schema(
   {
+    firebaseUid: {
+      type: String,
+      required: true,
+    },
     firstName: {
       type: String,
       minLength: 3,
@@ -38,12 +42,6 @@ const adminSchema = new Schema(
       type: String,
       minLength: 5,
       maxLength: 25,
-      required: true,
-    },
-    password: {
-      type: String,
-      minLength: 8,
-      maxLength: 20,
       required: true,
     },
   },

--- a/src/models/member.js
+++ b/src/models/member.js
@@ -3,6 +3,10 @@ const mongoose = require('mongoose');
 const { Schema } = mongoose;
 
 const membersSchema = new Schema({
+  firebaseUid: {
+    type: String,
+    required: true,
+  },
   firstName: {
     type: String,
     minLength: 3,
@@ -29,12 +33,6 @@ const membersSchema = new Schema({
   },
   email: {
     type: String,
-    required: true,
-  },
-  password: {
-    type: String,
-    minLength: 8,
-    maxLength: 16,
     required: true,
   },
   city: {

--- a/src/models/member.js
+++ b/src/models/member.js
@@ -57,7 +57,7 @@ const membersSchema = new Schema({
   },
   membership: {
     type: String,
-    required: true,
+    default: 'Only Classes',
     enum: ['Black', 'Classic', 'Gold', 'Only Classes', 'Silver'],
   },
 });

--- a/src/models/super-admins.js
+++ b/src/models/super-admins.js
@@ -3,6 +3,10 @@ const mongoose = require('mongoose');
 const { Schema } = mongoose;
 
 const superAdminsSchema = new Schema({
+  firebaseUid: {
+    type: String,
+    required: true,
+  },
   firstName: {
     type: String,
     minLength: 3,
@@ -11,12 +15,6 @@ const superAdminsSchema = new Schema({
   },
   email: {
     type: String,
-    required: true,
-  },
-  password: {
-    type: String,
-    minLength: 8,
-    maxLength: 16,
     required: true,
   },
 });

--- a/src/models/trainer.js
+++ b/src/models/trainer.js
@@ -3,6 +3,10 @@ const mongoose = require('mongoose');
 const { Schema } = mongoose;
 
 const trainersSchema = new Schema({
+  firebaseUid: {
+    type: String,
+    required: true,
+  },
   firstName: {
     type: String,
     minLength: 3,
@@ -39,12 +43,6 @@ const trainersSchema = new Schema({
     type: String,
     minLength: 5,
     maxLength: 20,
-    required: true,
-  },
-  password: {
-    type: String,
-    minLength: 4,
-    maxLength: 25,
     required: true,
   },
   salary: {

--- a/src/validations/member.js
+++ b/src/validations/member.js
@@ -100,6 +100,7 @@ const validateMembersCreation = (req, res, next) => {
   const membersValidation = Joi.object({
     firstName: Joi.string().regex(/^[A-Za-z]+\s?[A-Za-z]+$/).trim().min(3)
       .max(25)
+      .required()
       .messages({
         'string.pattern.base': 'Name must have only letters',
         'any.required': 'Name is required',
@@ -107,6 +108,7 @@ const validateMembersCreation = (req, res, next) => {
       }),
     lastName: Joi.string().regex(/^[A-Za-z]+\s?[A-Za-z]+$/).trim().min(3)
       .max(25)
+      .required()
       .messages({
         'string.pattern.base': 'Last name must have only letters',
         'any.required': 'Last name is required',
@@ -176,7 +178,6 @@ const validateMembersCreation = (req, res, next) => {
       }),
     isActive: Joi.boolean(),
     membership: Joi.string().valid('Black', 'Gold', 'Only Classes', 'Classic', 'Silver')
-      .required()
       .messages({
         'string.valid': 'Please enter a valid membership: Black, Gold, Silver',
         'any.required': 'Membership cannot be empty',


### PR DESCRIPTION
This pull request brings an improvement to our user creation process. Previously, user creation relied on MongoDB, but now we've made some changes to split the data between Firebase and MongoDB.

I made the following changes:
• Add the FirebaseUid to the super admin, admin, member, and trainer schema.
• Remove the password in the super admin, admin, member, and trainer schema.
• Update the controllers of super admin, admin, member, and trainer to send the password only to Firebase and not to MongoDB.
• Update the controllers of super admin, admin, member, and trainer to delete both data (MongoDB and Firebase).
• Add a conditional in class controllers to check if already exists a class in one day at the same hour.